### PR TITLE
Allow circular image theming and publicize fetchedResultsController

### DIFF
--- a/Classes/DNModelWatchFetchedObjects.h
+++ b/Classes/DNModelWatchFetchedObjects.h
@@ -14,6 +14,8 @@
 
 @interface DNModelWatchFetchedObjects : DNModelWatchObjects
 
+@property (nonatomic, retain) NSFetchedResultsController* fetchedResultsController;
+
 + (id)watchWithModel:(DNModel*)model andFetch:(NSFetchRequest*)fetch;
 
 - (id)initWithModel:(DNModel*)model andFetch:(NSFetchRequest*)fetch;

--- a/Classes/DNModelWatchFetchedObjects.m
+++ b/Classes/DNModelWatchFetchedObjects.m
@@ -11,12 +11,13 @@
 @interface DNModelWatchFetchedObjects () <NSFetchedResultsControllerDelegate>
 {
     NSFetchRequest*             fetchRequest;
-    NSFetchedResultsController* fetchResultsController;
 }
 
 @end
 
 @implementation DNModelWatchFetchedObjects
+
+@synthesize fetchedResultsController;
 
 + (id)watchWithModel:(DNModel*)model
             andFetch:(NSFetchRequest*)fetch
@@ -32,11 +33,11 @@
     {
         fetchRequest    = fetch;
         
-        fetchResultsController = [[NSFetchedResultsController alloc] initWithFetchRequest:fetchRequest
-                                                                     managedObjectContext:[[model class] managedObjectContext]
-                                                                       sectionNameKeyPath:nil
-                                                                                cacheName:nil];     // NSStringFromClass([self class])];
-        fetchResultsController.delegate = self;
+        fetchedResultsController = [[NSFetchedResultsController alloc] initWithFetchRequest:fetchRequest
+                                                                       managedObjectContext:[[model class] managedObjectContext]
+                                                                         sectionNameKeyPath:nil
+                                                                                  cacheName:nil];     // NSStringFromClass([self class])];
+        fetchedResultsController.delegate = self;
     }
     
     return self;
@@ -44,7 +45,7 @@
 
 - (NSArray*)objects
 {
-    return fetchResultsController.fetchedObjects;
+    return fetchedResultsController.fetchedObjects;
 }
 
 - (void)startWatch
@@ -64,7 +65,7 @@
     [super cancelWatch];
     
     fetchRequest            = nil;
-    fetchResultsController  = nil;
+    fetchedResultsController  = nil;
 }
 
 - (void)refreshWatch
@@ -73,9 +74,9 @@
     
     NSError*    error = nil;
     
-    fetchResultsController.fetchRequest.resultType = NSManagedObjectResultType;
+    fetchedResultsController.fetchRequest.resultType = NSManagedObjectResultType;
     
-    BOOL    result = [fetchResultsController performFetch:&error];
+    BOOL    result = [fetchedResultsController performFetch:&error];
     if (result == NO)
     {
         DLog(LL_Error, LD_CoreData, @"error=%@", [error localizedDescription]);

--- a/Classes/DNThemeManager.m
+++ b/Classes/DNThemeManager.m
@@ -321,7 +321,15 @@
     imgView.layer.borderColor   = [[[self class] performThemeSelectorForAttribute:@"BorderColor" withType:@"ImageView" andGroup:group andScreen:screen andViewState:viewState andItem:item] CGColor];
     imgView.layer.borderWidth   = [[[self class] performThemeSelectorForAttribute:@"BorderWidth" withType:@"ImageView" andGroup:group andScreen:screen andViewState:viewState andItem:item] doubleValue];
 
+    imgView.layer.cornerRadius  = [[[self class] performThemeSelectorForAttribute:@"CornerRadius" withType:@"ImageView" andGroup:group andScreen:screen andViewState:viewState andItem:item] doubleValue];
+    
     imgView.backgroundColor     = [[self class] performThemeSelectorForAttribute:@"BackgroundColor" withType:@"ImageView" andGroup:group andScreen:screen andViewState:viewState andItem:item];
+    
+    if ([[[self class] performThemeSelectorForAttribute:@"MakeCircle" withType:@"ImageView" andGroup:group andScreen:screen andViewState:viewState andItem:item] boolValue])
+    {
+        imgView.layer.cornerRadius = imgView.bounds.size.width / 2.0f;
+        imgView.layer.masksToBounds = YES;
+    }
 }
 
 + (void)customizeButton:(UIButton*)btnView


### PR DESCRIPTION
UIImageView needs to be circular in some cases so this commit allows theming to specify that.  UICollectionView needs access to the fetchedResultsController so this commit makes the fetchedResultsController a publicly accessible property.
